### PR TITLE
Deep copy get file dict

### DIFF
--- a/master-bin/detect_well_known_errors.py
+++ b/master-bin/detect_well_known_errors.py
@@ -28,6 +28,7 @@ import logging
 import argparse
 import fcntl
 from collections import deque
+from copy import deepcopy
 
 from piupartslib.conf import Config as PiupartsLibConfig
 from piupartslib.conf import MissingSection
@@ -89,10 +90,12 @@ def process_section(section, config, problem_list,
         kprdict = get_file_dict(workdirs, KPR_EXT)
         bugdict = get_file_dict(workdirs, BUG_EXT)
 
-        del_cnt = clean_cache_files(logdict, kprdict, recheck, recheck_failed)
+        cp_kprdict = deepcopy(kprdict)
+
+        del_cnt = clean_cache_files(logdict, cp_kprdict, recheck, recheck_failed)
         clean_cache_files(logdict, bugdict, skipnewer=True)
 
-        kprdict = get_file_dict(workdirs, KPR_EXT)
+        # kprdict = get_file_dict(workdirs, KPR_EXT)
 
         section_config = WKE_Config(section=section, defaults_section="global")
         section_config.read(CONFIG_FILE)

--- a/master-bin/detect_well_known_errors.py
+++ b/master-bin/detect_well_known_errors.py
@@ -29,7 +29,7 @@ import argparse
 import fcntl
 from collections import deque
 
-import piupartslib
+from piupartslib.conf import Config as PiupartsLibConfig
 from piupartslib.conf import MissingSection
 from piupartslib.dwke import *
 
@@ -44,13 +44,13 @@ class Busy(Exception):
         self.args = "section is locked by another process",
 
 
-class WKE_Config(piupartslib.conf.Config):
+class WKE_Config(PiupartsLibConfig):
 
     """Configuration parameters for Well Known Errors"""
 
     def __init__(self, section="global", defaults_section=None):
         self.section = section
-        piupartslib.conf.Config.__init__(self, section,
+        PiupartsLibConfig.__init__(self, section,
                                          {
                                          "sections": "report",
                                          "master-directory": ".",

--- a/piuparts-report.py
+++ b/piuparts-report.py
@@ -40,6 +40,7 @@ import random
 import fcntl
 from urllib2 import HTTPError, URLError
 from collections import deque
+from copy import deepcopy
 
 # if python-rpy2 ain't installed, we don't draw fancy graphs
 try:
@@ -1766,9 +1767,11 @@ def dwke_update_tpl(section, problem, failures, ftpl, ptpl, pkgsdb, srcdb):
 def dwke_get_failures(pkgsdb, problem_list):
     logdict = get_file_dict(KPR_DIRS, LOG_EXT)
     kprdict = get_file_dict(KPR_DIRS, KPR_EXT)
+    cp_kprdict = deepcopy(kprdict)
+
     del_cnt = clean_cache_files(logdict, kprdict)
-    kprdict = get_file_dict(KPR_DIRS, KPR_EXT)
-    add_cnt = make_kprs(logdict, kprdict, problem_list)
+    # kprdict = get_file_dict(KPR_DIRS, KPR_EXT)
+    add_cnt = make_kprs(logdict, cp_kprdict, problem_list)
 
     failures = FailureManager(logdict)
     failures.sort_by_bugged_and_rdeps(pkgsdb)


### PR DESCRIPTION
Hi @h01ger ,

Two files. Do not write 'kprdcit = get_file_dict(same params)'
twice.  Use copy.deepcopy() to be safe. [Python 2 doc](https://docs.python.org/2/library/copy.html).

The patch ends here.

Then, if this is acceptable, my idea is to remove the last 
param from 'get_file_dict' function.

 - import only 'LOG_EXT'  for piuparts-report.py file.  Used in [line 1741](https://github.com/hpfn-d/piuparts_3/blob/master/piuparts-report.py#L1741). 

 - the detect_well_known_errors.py file will not need to import any *_EXT.

The 'get_file_dict' function and the last param are imported 
from piupartslib/dwke.py.

The 'get_file_dict' function should then be used as:

# detect_well_known_errors
logditc, kprdict, bugdict = get_file_dict(dirs)

# piuparts-report.py
logdict, kprdict, _ = get_file_dict(dirs)